### PR TITLE
History event

### DIFF
--- a/js/jquery.clever-infinite-scroll.js
+++ b/js/jquery.clever-infinite-scroll.js
@@ -142,7 +142,7 @@
               documentHeight = $(document).height();
               $contents = $(settings.contentSelector);
               $("#cis-load-img").remove();
-              $(document).trigger('cleaver-infinite-scroll-content-loaded');
+              $(document).trigger('clever-infinite-scroll-content-loaded');
             }
           });
         }

--- a/js/jquery.clever-infinite-scroll.js
+++ b/js/jquery.clever-infinite-scroll.js
@@ -58,6 +58,7 @@
           $(settings.contentSelector).removeClass("active");
           $(_value).addClass("active");
           setTitleAndHistory(title, path);
+          $(document).trigger('clever-infinite-scroll-url-change', [title, path]);
         }
       };
 


### PR DESCRIPTION
Adds `clever-infinite-scroll-url-change` when url changes (so it's possible to, e.g., manually call Google Analytics visit API).

Also fixes a typo in `clever-infinite-scroll-content-loaded` event.